### PR TITLE
Adding missing dependancy for debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   - name: Install build tools
     apt: 
         name: ['gcc', 'g++', 'make', 'cmake', 'build-essential', 'git', 'autoconf', 'curl', 'libtool', 'libssl-dev', 'libcurl4-openssl-dev', 
-          'libz-dev', 'systemd-coredump', 'liblz4-tool']
+          'libz-dev', 'systemd-coredump', 'liblz4-tool', 'automake']
         state: latest
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 


### PR DESCRIPTION
Fix Can't exec "aclocal": No such file or directory error